### PR TITLE
Contador de turnos

### DIFF
--- a/src/Library/Entrenador.cs
+++ b/src/Library/Entrenador.cs
@@ -4,13 +4,15 @@ namespace Proyecto_Pokemones_I;
 
 public class Entrenador
 {
+    // Atributos:
     private string nombre;
     private Pokemon? pokemonEnUso;
     private List<Pokemon> seleccionPokemones;
     private int pokemonesVivos;
     private List<IItems> listItems;
+    private int turnosRecargaAtkEspecial;
 
-    //Getters:
+    // Getters:
     public string GetNombre()
     {
         return this.nombre;
@@ -35,7 +37,6 @@ public class Entrenador
         }
         return pokemonesVivos;
     }
-
     public string GetListaDeItems()
     {
         Dictionary<string, int> itemCounts = new Dictionary<string, int>();
@@ -60,10 +61,8 @@ public class Entrenador
             resultado += $"{entry.Key} (x{entry.Value}) ";
             Console.Write($"{entry.Key} (x{entry.Value}) / ");
         }
-    
         return resultado.Trim(); // Elimina el último espacio extra al final de la cadena
     }
-
   
     // Constructor:
     public Entrenador(string suNombre)
@@ -72,19 +71,28 @@ public class Entrenador
         this.pokemonEnUso = null;
         this.seleccionPokemones = new List<Pokemon>();
         this.pokemonesVivos = 6;
-        listItems = new List<IItems>();
-        for (int i = 0; i <= 3; i++)
+        this.turnosRecargaAtkEspecial = 2;      // Decidimos que por defecto no se pueda usar el ataque especial en los primeros dos turnos
+        this.listItems = new List<IItems>();
+        this.RecargarItems();
+    }
+
+    // Métodos:
+    public void RecargarItems()
+    {
+        for (int i = 0; i < 4; i++)    // Agrega 4 Super Poción
         {
             SuperPociones pocion = new SuperPociones();
             listItems.Add(pocion);
         }
-
-        Revivir resusitacion = new Revivir();
+        
+        Revivir resusitacion = new Revivir();   // Agrega 1 Revivir
         listItems.Add(resusitacion);
-        CuraTotal curaTotal = new CuraTotal();
-        listItems.Add(curaTotal);
 
-
+        for (int i = 0; i < 2; i++)
+        {
+            CuraTotal curaTotal = new CuraTotal();  // Agrega 2 Cura Total
+            listItems.Add(curaTotal);
+        }
     }
 
     public void AñadirASeleccion(Pokemon elPokemon)

--- a/src/Library/Entrenador.cs
+++ b/src/Library/Entrenador.cs
@@ -10,7 +10,7 @@ public class Entrenador
     private List<Pokemon> seleccionPokemones;
     private int pokemonesVivos;
     private List<IItems> listItems;
-    private int turnosRecargaAtkEspecial;
+    public int TurnosRecargaAtkEspecial { get; set; }
 
     // Getters:
     public string GetNombre()
@@ -71,7 +71,7 @@ public class Entrenador
         this.pokemonEnUso = null;
         this.seleccionPokemones = new List<Pokemon>();
         this.pokemonesVivos = 6;
-        this.turnosRecargaAtkEspecial = 2;      // Decidimos que por defecto no se pueda usar el ataque especial en los primeros dos turnos
+        this.TurnosRecargaAtkEspecial = 2;      // Decidimos que por defecto no se pueda usar el ataque especial en los primeros dos turnos
         this.listItems = new List<IItems>();
         this.RecargarItems();
     }

--- a/src/Library/Entrenador.cs
+++ b/src/Library/Entrenador.cs
@@ -158,5 +158,8 @@ public class Entrenador
         return result;
     }
 
-
+    public void AceptarVisitorPorTurno(VisitorPorTurno visitor)
+    {
+        visitor.VisitarEntrenador(this);
+    }
 }

--- a/src/Library/Fachada.cs
+++ b/src/Library/Fachada.cs
@@ -11,6 +11,7 @@ public class Fachada
     public List<Entrenador> Jugadores { get; private set; }
     public Entrenador entrenadorConTurno;
     public Entrenador entrenadorSinTurno;
+    private VisitorPorTurno visitorTurno;
     public bool existeGanador = false;
 
     // Getters:
@@ -27,6 +28,7 @@ public class Fachada
     private Fachada()
     {
         Jugadores = new List<Entrenador>();
+        visitorTurno = new VisitorPorTurno();
     }
 
     // Métodos: (En orden de aparición en la Batalla)
@@ -136,6 +138,7 @@ public class Fachada
             entrenadorConTurno = Jugadores[0];
             entrenadorSinTurno = Jugadores[1];
         }
+        entrenadorConTurno.AceptarVisitorPorTurno(this.visitorTurno);
     }
     
     public void ChequearQuienEmpieza()
@@ -177,23 +180,6 @@ public class Fachada
         Pokemon pokemonAtacante = entrenadorConTurno.GetPokemonEnUso();
         
         bool ataqueExitoso = true;
-        
-        /*--------------------------------------------------------------------------------------------------------------
-         ESTO NO VA ACÁ, ES DAÑO POR TURNO, DECIDA ATACAR, GUARDAR O USAR ITEM. SE APLICA CADA VEZ QUE ES MI TURNO
-         ---------------------------------------------------------------------------------------------------------------
-         if (pokemonVictima.EfectoActivo == "Envenenado")
-        {
-            pokemonVictima.DañoPorTurno(5);
-            Console.WriteLine($"{pokemonVictima.GetNombre()} sufrirá más daño por estar envenenado, su vida es {entrenadorSinTurno.GetPokemonEnUso().GetVida()}");
-        } //Si el Pokemon que recibe daño está envenenado
-
-        if (pokemonVictima.EfectoActivo == "Quemado")
-        {
-            pokemonVictima.DañoPorTurno(10);
-            Console.WriteLine($"{pokemonVictima.GetNombre()} sufrirá más daño por estar quemado, su vida es {entrenadorConTurno.GetPokemonEnUso().GetVida()}");
-        } //Si el Pokemon que recibe daño está quemado
-        ----------------------------------------------------------------------------------------------------------------
-        */
         
         // Si es el turno del Jugador 1, intentará efectuar el ataque indicado sobre el Pokemon en Uso del Jugador 2
         foreach (IAtaque ataque in pokemonAtacante.GetAtaques())

--- a/src/Library/Fachada.cs
+++ b/src/Library/Fachada.cs
@@ -156,8 +156,6 @@ public class Fachada
                           $"El Pokémon usado es {entrenadorSinTurno.GetPokemonEnUso().GetNombre()}, " +
                           $"vida = {(entrenadorSinTurno.GetPokemonEnUso().GetVida() <= 0 ? "muerto" : entrenadorSinTurno.GetPokemonEnUso().GetVida().ToString())}/{entrenadorSinTurno.GetPokemonEnUso().GetVidaMax()}" +
                           $"{(entrenadorSinTurno.GetPokemonEnUso().GetVida() > 0 ? $", su estado = {(entrenadorSinTurno.GetPokemonEnUso().EfectoActivo ?? "consciente")}" : "")}\n");
-
-
     }
     
     public string ListaAtaques()

--- a/src/Library/Items/CuraTotal.cs
+++ b/src/Library/Items/CuraTotal.cs
@@ -17,6 +17,7 @@ public class CuraTotal:IItems
     public void ActivarItem(Pokemon pokemon)
     {
         pokemon.EfectoActivo = null;
+        pokemon.PuedeAtacar = true;
     }
     
 }

--- a/src/Library/Items/SuperPociones.cs
+++ b/src/Library/Items/SuperPociones.cs
@@ -19,7 +19,7 @@ public class SuperPociones :IItems
 
     public void ActivarItem(Pokemon pokemon)
     {
-        pokemon.AumentarVida(Vida);
+        pokemon.AlterarVida(Vida);
     }
 
 }

--- a/src/Library/LeerArchivo.cs
+++ b/src/Library/LeerArchivo.cs
@@ -4,8 +4,7 @@ namespace Proyecto_Pokemones_I;
 
 public static class LeerArchivo
 {
-    public static string RutaCatalogo =
-        "/Users/andrespimienta/Desktop/Facultad/Programación 2/Proyecto/Pokemones2/src/Program/CatalogoPokemones.txt";
+    public static string RutaCatalogo = "C:\\Users\\Estudiante UCU\\Documents\\Repositorios Prog. II\\Pokemones2\\src\\Program\\CatalogoPokemones.txt";
 
     public static void ImprimirCatalogoProcesado()
     {

--- a/src/Library/LeerArchivo.cs
+++ b/src/Library/LeerArchivo.cs
@@ -4,7 +4,8 @@ namespace Proyecto_Pokemones_I;
 
 public static class LeerArchivo
 {
-    public static string RutaCatalogo = "C:\\Users\\Estudiante UCU\\Documents\\Repositorios Prog. II\\Pokemones2\\src\\Program\\CatalogoPokemones.txt";
+    public static string RutaCatalogo =
+        "/Users/andrespimienta/Desktop/Facultad/Programación 2/Proyecto/Pokemones2/src/Program/CatalogoPokemones.txt";
 
     public static void ImprimirCatalogoProcesado()
     {

--- a/src/Library/Pokemon.cs
+++ b/src/Library/Pokemon.cs
@@ -11,7 +11,8 @@ public class Pokemon
     private double velocidadAtaque;
     private List<IAtaque> listadoAtaques;
     public string EfectoActivo { get; set;}
-    public int TurnosDuracionEfecto { get; private set; }
+    public bool PuedeAtacar { get; set; }
+    public int TurnosDuracionEfecto { get; set; }
     
     //Getters:
     public string GetNombre()
@@ -51,6 +52,7 @@ public class Pokemon
         this.velocidadAtaque = pokeVelAtaque;
         this.listadoAtaques = ataques;
         this.EfectoActivo = null;
+        this.PuedeAtacar = true;
         this.TurnosDuracionEfecto = 0;
     }
     

--- a/src/Library/Pokemon.cs
+++ b/src/Library/Pokemon.cs
@@ -10,7 +10,7 @@ public class Pokemon
     private double vidaMax;
     private double velocidadAtaque;
     private List<IAtaque> listadoAtaques;
-    public string EfectoActivo { get; private set;}
+    public string EfectoActivo { get; set;}
     public int TurnosDuracionEfecto { get; private set; }
     
     //Getters:
@@ -130,7 +130,7 @@ public class Pokemon
         }
     }
 
-    public void AumentarVida(double hp)
+    public void AlterarVida(double hp)
     {
         this.vida += hp;
     }

--- a/src/Library/Pokemon.cs
+++ b/src/Library/Pokemon.cs
@@ -11,6 +11,7 @@ public class Pokemon
     private double velocidadAtaque;
     private List<IAtaque> listadoAtaques;
     public string EfectoActivo { get; set;}
+    public int turnosDuracionEfecto;
     
     //Getters:
     public string GetNombre()

--- a/src/Library/Pokemon.cs
+++ b/src/Library/Pokemon.cs
@@ -10,8 +10,8 @@ public class Pokemon
     private double vidaMax;
     private double velocidadAtaque;
     private List<IAtaque> listadoAtaques;
-    public string EfectoActivo { get; set;}
-    public int turnosDuracionEfecto;
+    public string EfectoActivo { get; private set;}
+    public int TurnosDuracionEfecto { get; private set; }
     
     //Getters:
     public string GetNombre()
@@ -38,7 +38,9 @@ public class Pokemon
     {
         return this.listadoAtaques;
     }
+
     
+
     //Constructor:
     public Pokemon(string pokeNombre, string pokeTipo, double pokeVida, double pokeVelAtaque, List<IAtaque> ataques)
     {
@@ -48,7 +50,8 @@ public class Pokemon
         this.vidaMax = pokeVida;
         this.velocidadAtaque = pokeVelAtaque;
         this.listadoAtaques = ataques;
-        EfectoActivo = null;
+        this.EfectoActivo = null;
+        this.TurnosDuracionEfecto = 0;
     }
     
     // Métodos:
@@ -107,6 +110,12 @@ public class Pokemon
                     EfectoActivo = efectoAtaque.Substring(0,efectoAtaque.Length - 1) + "DO";
                     // Aclaración: "Dormi" + "do" | "Paraliza" + "do" | "Envenena" + "do" | "Quema" + "do"
                     Console.WriteLine($"{this.nombre} ahora está {EfectoActivo}");
+                    
+                    // Si el efecto era Dormir, genera una duración de efecto de entre 1 y 4 turnos
+                    if (ataqueRecibido.GetEfecto() == "DORMIR")
+                    {
+                        this.TurnosDuracionEfecto = ProbabilityUtils.DuracionEfecto(1,4);
+                    }
                 }
                 else
                 {

--- a/src/Library/ProbabilityUtils.cs
+++ b/src/Library/ProbabilityUtils.cs
@@ -18,4 +18,11 @@ public class ProbabilityUtils
             return false;
         }
     }
+
+    public static int DuracionEfecto(int turnosMin, int turnosMax)
+    {
+        Random generadorAleatorio = new Random();
+        int numeroAleatorio = generadorAleatorio.Next(turnosMin, turnosMax+1);
+        return numeroAleatorio;
+    }
 }

--- a/src/Library/VisitorPorTurno.cs
+++ b/src/Library/VisitorPorTurno.cs
@@ -1,0 +1,33 @@
+﻿namespace Proyecto_Pokemones_I;
+
+public class VisitorPorTurno
+{
+    public void VisitarEntrenador(Entrenador entrenadorVisitado)
+    {
+        if (entrenadorVisitado.TurnosRecargaAtkEspecial > 0)    // Si el Entrenador tenía turnos de enfriamiento para los ataques especiales, le resta un turno
+        {
+            entrenadorVisitado.TurnosRecargaAtkEspecial -= 1;
+        }
+
+        foreach (Pokemon pokemon in entrenadorVisitado.GetSeleccion())  // Chequea si alguno de los pokemones del Entrenador tiene algún efecto
+        {
+            string statusPokemon = pokemon.EfectoActivo;
+            if (statusPokemon != null)  // Solo va a hacer cosas si el pokemon tiene algún efecto activo
+            {
+                switch (statusPokemon)  // Lo que le va a hacer al pokemon dependerá del efecto
+                {
+                    case "QUEMADO" 
+                    {
+                        pokemon.AlterarVida(-pokemon.GetVidaMax() * 0.1);
+                    }
+                    case "ENVENENADO" 
+                    {
+                        pokemon.AlterarVida(-pokemon.GetVidaMax() * 0.1);
+                    }
+                }
+            }
+
+            
+        }
+    }
+}

--- a/src/Library/VisitorPorTurno.cs
+++ b/src/Library/VisitorPorTurno.cs
@@ -16,17 +16,56 @@ public class VisitorPorTurno
             {
                 switch (statusPokemon)  // Lo que le va a hacer al pokemon dependerá del efecto
                 {
-                    case "QUEMADO" 
+                    case "DORMIDO":
                     {
-                        pokemon.AlterarVida(-pokemon.GetVidaMax() * 0.1);
+                        // Si está dormido, reduce en 1 los turnos que falta para que despierte
+                        pokemon.TurnosDuracionEfecto -= 1;
+                        
+                        // Si ya pasaron todos los turnos hasta que despierte, lo despierta (le quita el efecto y le permite atacar)
+                        if (pokemon.TurnosDuracionEfecto == -1)
+                        {
+                            pokemon.EfectoActivo = null;
+                            pokemon.PuedeAtacar = true;
+                            Console.WriteLine($"El Pokemon {pokemon.GetNombre()} se ha despertado");
+                        }
+                        else
+                        {
+                            pokemon.PuedeAtacar = false;
+                            Console.WriteLine($"El Pokemon {pokemon.GetNombre()} seguirá dormido {pokemon.TurnosDuracionEfecto} turnos más");
+                        }
+                        break;
                     }
-                    case "ENVENENADO" 
+                    case "PARALIZADO":
                     {
+                        // Si está paralizado, hay un 33% de chance de que el pokemon paralizado pueda atacar en cada turno
+                        pokemon.PuedeAtacar = false;
+                        if (ProbabilityUtils.Probabilometro(33))    
+                        {
+                            pokemon.PuedeAtacar = true;
+                            Console.WriteLine($"El Pokemon {pokemon.GetNombre()}, a pesar de estar paralizado, puede atacar");
+                        }
+                        else
+                        {
+                            Console.WriteLine($"El Pokemon {pokemon.GetNombre()}, está paralizado, no puede atacar");
+                        }
+                        break;
+                    }
+                    case "QUEMADO":
+                    {
+                        // Si está quemado, le resta el 10% de la vida en cada turno
                         pokemon.AlterarVida(-pokemon.GetVidaMax() * 0.1);
+                        Console.WriteLine($"El Pokemon {pokemon.GetNombre()} perdió {pokemon.GetVidaMax() * 0.1} puntos de salud por quemadura");
+                        break;
+                    }
+                    case "ENVENENADO":
+                    {
+                        // Si está envenenado, le resta el 5% de la vida en cada turno
+                        pokemon.AlterarVida(-pokemon.GetVidaMax() * 0.05);
+                        Console.WriteLine($"El Pokemon {pokemon.GetNombre()} perdió {pokemon.GetVidaMax() * 0.05} puntos de salud por envenenamiento");
+                        break;
                     }
                 }
             }
-
             
         }
     }


### PR DESCRIPTION
En esta rama creé un visitor que cada vez que cambia el turno, visita al entrenador de turno y le resta todos los tiempos de recarga (para ataques especiales y pokemones dormidos), además de aplicarle el daño correspondiente de quemar y envenenar a todos los pokemones que estén bajo esos efectos. También decide si un pokemon paralizado tiene chance de atacar o no.